### PR TITLE
fix: canonicalize mRID before Blazegraph get_object (TO-005)

### DIFF
--- a/tests/test_mrid_canonicalize.py
+++ b/tests/test_mrid_canonicalize.py
@@ -1,0 +1,181 @@
+"""Unit tests for the TO-005 caller-side mRID fix in topo_background_service.
+
+topo_background_service imports gridappsd and cimgraph at module scope; those are
+container-only dependencies. We stub them in sys.modules before import so the
+pure-Python canonicalization and the None-vs-empty distinction can be exercised
+without the broker or Blazegraph.
+"""
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _install_stubs():
+    """Register lightweight stand-ins for the container-only dependencies."""
+
+    class _Feeder:
+        pass
+
+    class _FeederArea:
+        pass
+
+    class _DistributionArea:
+        pass
+
+    class _GridAPPSD:
+        def __init__(self, *a, **k):
+            self.connected = True
+
+        def get_logger(self):
+            return mock.MagicMock()
+
+    gridappsd_mod = types.ModuleType('gridappsd')
+    gridappsd_mod.GridAPPSD = _GridAPPSD
+    sys.modules['gridappsd'] = gridappsd_mod
+
+    cimgraph = types.ModuleType('cimgraph')
+    databases = types.ModuleType('cimgraph.databases')
+    blazegraph = types.ModuleType('cimgraph.databases.blazegraph')
+    blazegraph.BlazegraphConnection = mock.MagicMock
+    databases.blazegraph = blazegraph
+    cimgraph.databases = databases
+    sys.modules['cimgraph'] = cimgraph
+    sys.modules['cimgraph.databases'] = databases
+    sys.modules['cimgraph.databases.blazegraph'] = blazegraph
+
+    cim = types.ModuleType('cimgraph.data_profile.cimhub_2023')
+    cim.Feeder = _Feeder
+    cim.FeederArea = _FeederArea
+    cim.DistributionArea = _DistributionArea
+    data_profile = types.ModuleType('cimgraph.data_profile')
+    data_profile.cimhub_2023 = cim
+    cimgraph.data_profile = data_profile
+    sys.modules['cimgraph.data_profile'] = data_profile
+    sys.modules['cimgraph.data_profile.cimhub_2023'] = cim
+
+    class _DistributedTopologyMessage:
+        def __init__(self):
+            self.message = {'DistributionArea': {}}
+
+        def get_context_from_feeder(self, *a, **k):
+            # Simulate a populated topology for the resolved-Feeder success case.
+            self.message['DistributionArea'] = {'@id': 'stub', 'Substations': []}
+
+        def get_context_from_feeder_area(self, *a, **k):
+            pass
+
+        def get_context_from_distribution_area(self, *a, **k):
+            pass
+
+    utils = types.ModuleType('topology_processor.utils')
+    utils.DistributedTopologyMessage = _DistributedTopologyMessage
+    tp = types.ModuleType('topology_processor')
+    tp.utils = utils
+    sys.modules.setdefault('topology_processor', tp)
+    sys.modules['topology_processor.utils'] = utils
+
+    dotenv = types.ModuleType('dotenv')
+    dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules['dotenv'] = dotenv
+
+    return cim
+
+
+@pytest.fixture(scope='module')
+def svc_module():
+    _install_stubs()
+    mod = importlib.import_module('topo_background_service')
+    return importlib.reload(mod)
+
+
+# --- canonicalization ---------------------------------------------------------
+
+# ieee123 Feeder mRID stored by Blazegraph as bare lowercase urn:uuid.
+CANONICAL = 'c1c3e687-6ffd-c753-582b-632a27e28507'
+
+
+@pytest.mark.parametrize('raw', [
+    'C1C3E687-6FFD-C753-582B-632A27E28507',      # plain uppercase (FieldBusManager form)
+    'c1c3e687-6ffd-c753-582b-632a27e28507',      # already canonical
+    '_C1C3E687-6FFD-C753-582B-632A27E28507',     # underscore-prefixed RDF ID, uppercase
+    '_c1c3e687-6ffd-c753-582b-632a27e28507',     # underscore-prefixed, lowercase
+    'C1c3E687-6ffd-C753-582b-632A27e28507',      # mixed case
+])
+def test_canonicalize_maps_any_form_to_bare_lowercase(svc_module, raw):
+    assert svc_module.canonicalize_mrid(raw) == CANONICAL
+
+
+@pytest.mark.parametrize('bad', ['not-a-uuid', '', 'urn:uuid:xyz', None, 12345])
+def test_canonicalize_returns_none_for_malformed(svc_module, bad):
+    assert svc_module.canonicalize_mrid(bad) is None
+
+
+# --- None-vs-empty distinction ------------------------------------------------
+
+def _build_service(svc_module, get_object_return):
+    """Construct a TopologyProcessor with __init__ bypassed and a stubbed conn."""
+    svc = svc_module.TopologyProcessor.__new__(svc_module.TopologyProcessor)
+    svc.gapps = mock.MagicMock()
+    svc.log = mock.MagicMock()
+    svc.blazegraph = mock.MagicMock()
+    svc.blazegraph.get_object.return_value = get_object_return
+    svc.return_message = {}
+    return svc
+
+
+def _sent_payload(svc):
+    assert svc.gapps.send.called, 'service never sent a reply'
+    return svc.gapps.send.call_args.args[1]
+
+
+def test_unresolved_mrid_signals_not_found_not_empty_success(svc_module):
+    """get_object -> None must produce a distinguishable not-found error, not {}."""
+    svc = _build_service(svc_module, get_object_return=None)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS',
+               'mRID': 'C1C3E687-6FFD-C753-582B-632A27E28507'}
+
+    svc.on_message(headers, message)
+
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' in payload, 'None path must emit an explicit error field'
+    assert 'DistributionArea' not in payload, 'must not masquerade as empty-but-valid topology'
+    assert svc.log.error.called, 'None path must log an actionable error'
+
+
+def test_malformed_mrid_signals_error_before_query(svc_module):
+    svc = _build_service(svc_module, get_object_return=None)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS', 'mRID': 'not-a-uuid'}
+
+    svc.on_message(headers, message)
+
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' in payload
+    svc.blazegraph.get_object.assert_not_called()
+    assert svc.log.error.called
+
+
+def test_resolved_feeder_keeps_success_shape(svc_module):
+    """A genuine Feeder still yields the DistributionArea success message."""
+    feeder = svc_module.cim.Feeder()
+    svc = _build_service(svc_module, get_object_return=feeder)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS',
+               'mRID': 'C1C3E687-6FFD-C753-582B-632A27E28507'}
+
+    svc.on_message(headers, message)
+
+    # get_object was called with the canonicalized mRID, not the raw uppercase form.
+    svc.blazegraph.get_object.assert_called_once_with(mRID=CANONICAL)
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' not in payload
+    assert 'DistributionArea' in payload

--- a/topo_background_service.py
+++ b/topo_background_service.py
@@ -1,12 +1,30 @@
 import os
 import json
 import time
+from uuid import UUID
 from gridappsd import GridAPPSD
 from cimgraph.databases.blazegraph import BlazegraphConnection
 
 from topology_processor.utils import DistributedTopologyMessage
 import cimgraph.data_profile.cimhub_2023 as cim
 from dotenv import load_dotenv
+
+
+def canonicalize_mrid(mrid: str) -> str | None:
+    """Normalize an mRID to the bare lowercase UUID that Blazegraph stores.
+
+    FieldBusManager sends the mRID in varied forms (plain uppercase UUID,
+    underscore-prefixed RDF ID, mixed case). cimgraph's create_object keys the
+    graph on UUID(uri.strip('_').lower()) but get_object_sparql does not
+    canonicalize the lookup, so an uncanonicalized mRID silently misses. Parse
+    to a UUID here (matching create_object) so the lookup is robust to any input
+    form. Returns None when the mRID is not a valid UUID so the caller can fail
+    loudly instead of querying with garbage.
+    """
+    try:
+        return str(UUID(mrid.strip('_').lower()))
+    except (ValueError, AttributeError):
+        return None
 
 # Uncomment and set following environment variables if testing outside GridAPPS-D container
 #os.environ["GRIDAPPSD_ADDRESS"] = ''
@@ -49,18 +67,37 @@ class TopologyProcessor(GridAPPSD):
                 self.gapps.send(reply_to, self.return_message[model_mrid])
             
             else:
-            
+
+                query_mrid = canonicalize_mrid(model_mrid)
+                if query_mrid is None:
+                    error = f'mRID {model_mrid!r} is not a valid UUID; cannot build topology'
+                    self.log.error(error)
+                    self.gapps.send(reply_to, json.dumps({'error': error}, indent=4))
+                    return
+
                 topo_message = DistributedTopologyMessage()
-                container = self.blazegraph.get_object(mRID=model_mrid)
+                container = self.blazegraph.get_object(mRID=query_mrid)
 
                 if isinstance(container, cim.Feeder):
                     topo_message.get_context_from_feeder(container, self.blazegraph)
 
                 elif isinstance(container, cim.FeederArea):
                     topo_message.get_context_from_feeder_area(container, self.blazegraph)
-                    
+
                 elif isinstance(container, cim.DistributionArea):
                     topo_message.get_context_from_distribution_area(container, self.blazegraph)
+
+                elif container is None:
+                    # get_object found no container for this mRID. Do NOT serialize
+                    # an empty DistributionArea as success: the caller cannot tell
+                    # that from a legitimately-empty topology. Signal not-found
+                    # explicitly so FieldBusManager can distinguish the two.
+                    error = (f'No container resolved for mRID {model_mrid!r} '
+                             f'(queried as {query_mrid}); topology not built')
+                    self.log.error(error)
+                    del topo_message
+                    self.gapps.send(reply_to, json.dumps({'error': error}, indent=4))
+                    return
 
                 self.return_message[model_mrid] = json.dumps(topo_message.message, indent=4)
                 del topo_message


### PR DESCRIPTION
## Problem

`topo_background_service.py` passed the request mRID verbatim to `self.blazegraph.get_object(mRID=...)`. FieldBusManager sends the mRID in varied forms (plain uppercase UUID, underscore-prefixed RDF ID, mixed case). cimgraph's `create_object` keys the graph on `UUID(uri.strip('_').lower())`, but `get_object_sparql` does NOT canonicalize the lookup. An uncanonicalized mRID silently missed: `get_object` returned `None`, no `isinstance` branch fired, and an empty `{"DistributionArea": {}}` serialized back as a success reply. FieldBusManager received a null topology with no error.

## Change (caller-side only, `topo_background_service.py`)

1. **Canonicalize before lookup.** New `canonicalize_mrid()` normalizes any input form via `UUID(mrid.strip('_').lower())` (matching `create_object`) and returns the bare lowercase UUID used in the query. A malformed mRID returns `None` so the handler can fail loudly instead of querying with garbage.
2. **Silent-failure visibility.** When `get_object` returns `None`, the handler no longer serializes an empty `DistributionArea` as success. It logs an actionable error naming the mRID and replies with an explicit `{"error": ...}` payload, so a caller can distinguish "mRID did not resolve" from a legitimately-empty topology. The resolved-container success shape is unchanged.

Upstream cimgraph normalization is tracked separately (TO-004); this PR is the caller-side guard only.

## Verification

Live stack (gridappsd + blazegraph:develop, cim-graph 0.5.0a7):

- `get_object` with underscore-prefixed uppercase mRID: `None` before, `Feeder` after canonicalization.
- `GET_DISTRIBUTED_AREAS` for ieee123 (uppercase mRID): populated `DistributionArea` (1 Substation, ~253 KB) where the raw path produced empty.
- ieee13 (uppercase mRID): populated (~66 KB).
- Valid-but-nonexistent mRID: explicit not-found error, logged, no silent empty-success.
- Malformed (non-UUID) mRID: explicit error before any query.

Unit tests: `tests/test_mrid_canonicalize.py` (first tests in the repo). 13 pass. Cover the canonicalization table (uppercase / underscore / mixed / malformed) and the None-vs-empty distinction with the cimgraph and gridappsd imports stubbed, so no broker or Blazegraph is required.