### PR TITLE
fix: seed prerelease baseline at revision 1 (psr falsy-revision-0 bug)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "gridappsd-topology-processor"
 # published to PyPI carries the PEP440 spelling PyPI expects. Do not hand-edit
 # this string on develop: the dev-deploy workflow owns it. See
 # .github/workflows/deploy-dev-release.yml and [tool.semantic_release] below.
-version = "0.4.0-a.0"
+version = "0.4.0-a.1"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",
@@ -54,9 +54,16 @@ build-backend = "poetry.core.masonry.api"
 # semantic-release is strictly SemVer; PyPI and poetry are PEP440. The two forms
 # are equivalent for alpha prereleases: semantic-release writes 0.4.0-a.N and
 # poetry build normalizes it to 0.4.0aN. The baseline tag MUST be the SemVer form
-# (v0.4.0-a.0) so semantic-release can parse it; a PEP440-form tag such as
+# (v0.4.0-a.1) so semantic-release can parse it; a PEP440-form tag such as
 # v0.4.0a0 is unparseable to semantic-release and forces the baseline back to
 # 0.0.0, restarting version numbering.
+#
+# The prerelease revision MUST be >= 1 when seeding. Never seed revision 0
+# (v0.4.0-a.0). python-semantic-release v10.6.1 treats a prerelease revision of 0
+# as falsy: it drops the ".0" suffix and stringifies the seed as the bare
+# v0.4.0, then runs git rev-list against that nonexistent tag and dies. It also
+# reads a bare v0.4.0 as a shipped full release, which kills the prerelease
+# channel. Seed at v0.4.0-a.1 and let semantic-release count up from there.
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
 tag_format = "v{version}"


### PR DESCRIPTION
## What
Bump the pyproject dev-channel baseline version from `0.4.0-a.0` to `0.4.0-a.1`, and document in the `[tool.semantic_release]` comment why the prerelease revision must never be 0.

## Why
python-semantic-release v10.6.1 treats a prerelease revision of 0 as falsy. A seed of `v0.4.0-a.0` stringifies to the bare `v0.4.0`, psr then runs `git rev-list v0.4.0` against a nonexistent tag and dies. psr also reads a bare `v0.4.0` as a shipped full release, which would kill the alpha prerelease channel.

The origin tag has already been reseeded: `v0.4.0-a.0` is deleted and `v0.4.0-a.1` now points at the same seed commit (`34df7d6`).

## Scope
Comment and version-string change to `pyproject.toml` only. No workflow logic changed. The seed guidance lived solely in the pyproject comment, not in `deploy-dev-release.yml`, so no workflow file is touched.

## Verify plan
Merge to develop auto-fires `deploy-dev-release`; psr should compute the next alpha (~`0.4.0-a.2`) from the seed plus merge commits, commit the bump back, and publish to PyPI.