### PR TITLE
release: promote develop to main (GADP-007 mRID fix + semver-CI adoption + cimgraph pins)

### DIFF
--- a/.github/workflows/deploy-dev-release.yml
+++ b/.github/workflows/deploy-dev-release.yml
@@ -1,5 +1,28 @@
 ---
-name: Deploy Pre-Release Artifacts
+# Deploy a semver prerelease on push to develop.
+#
+# This repo adopts Semantic Versioning (see CHANGELOG.md). The published version
+# is read verbatim from pyproject.toml, which carries a prerelease semver such as
+# 0.4.0a0. This workflow no longer calls the shared GRIDAPPSD/.github reusable
+# workflow, because that workflow computes the next version from the highest
+# non-prerelease git tag and git-restores pyproject, ignoring the pyproject
+# version entirely. On this repo the highest such tag is the CalVer v2023.6.1,
+# which always outsorts any semver v0.4.0 tag, so the shared flow keeps trying to
+# republish a CalVer alpha (2023.6.3a0) and fails with a PyPI 400 File already
+# exists. Seeding a v0.4.0 tag cannot win against the CalVer tag. Adopting semver
+# therefore requires deriving the version from pyproject.toml, so the dev job is
+# implemented locally.
+#
+# PyPI is append-only: publishing the same version twice fails. To publish a new
+# prerelease, advance the prerelease number in pyproject.toml (0.4.0a0 to
+# 0.4.0a1, and so on) in the change that lands on develop.
+#
+# GitHub-hosted runner is acceptable here: this is a non-deploy-bearing publish
+# job that authenticates only with the ephemeral GITHUB_TOKEN plus PYPI_TOKEN to
+# create a GitHub prerelease and publish to PyPI. It does not SSH to any target
+# and does not touch a running environment. See .claude/rules/devops.md.
+
+name: Deploy Pre-Release Artifacts (semver)
 
 on:
   push:
@@ -17,12 +40,65 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
-  call-deploy-release:
+  deploy-dev-release:
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-22.04
     permissions:
-      contents: write  # To push a branch
-      pull-requests: write  # To create a PR from that branch
+      contents: write  # To create the prerelease
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
 
-    uses: GRIDAPPSD/.github/.github/workflows/deploy-dev-release.yml@main
-    secrets:
-      git-token: ${{ secrets.GITHUB_TOKEN }}
-      pypi-token: ${{ secrets.PYPI_TOKEN }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Read and validate prerelease version from pyproject
+        id: resolve
+        run: |
+          VERSION=$(poetry version --short)
+          # The dev channel only ever publishes a prerelease (alpha, beta, rc, or
+          # dev). A bare stable version on develop is a mistake: fail loudly so a
+          # stable version is never published from the dev channel by accident.
+          if ! echo "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc|\.dev)[0-9]+$'; then
+            echo "error: pyproject version '${VERSION}' is not a prerelease; the dev channel publishes prereleases only (for example 0.4.0a0)" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing prerelease version: ${VERSION}"
+
+      - name: Build
+        run: |
+          poetry build -vvv
+
+      - name: Twine check artifacts
+        run: |
+          pip install --quiet twine
+          twine check dist/*
+
+      - name: Create GitHub prerelease
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*.gz,dist/*.whl"
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: true
+          commit: ${{ github.sha }}
+          prerelease: true
+          tag: "v${{ steps.resolve.outputs.version }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish prerelease to PyPI
+        if: ${{ github.repository_owner == 'GRIDAPPSD' }}
+        run: |
+          poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
+          poetry publish

--- a/.github/workflows/deploy-dev-release.yml
+++ b/.github/workflows/deploy-dev-release.yml
@@ -47,7 +47,7 @@ jobs:
       contents: write  # To create the prerelease
     steps:
       - name: Checkout develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: develop
@@ -58,7 +58,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263  # v1.4.2
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -87,7 +87,7 @@ jobs:
           twine check dist/*
 
       - name: Create GitHub prerelease
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: "dist/*.gz,dist/*.whl"
           artifactErrorsFailBuild: true
@@ -99,6 +99,7 @@ jobs:
 
       - name: Publish prerelease to PyPI
         if: ${{ github.repository_owner == 'GRIDAPPSD' }}
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: |
-          poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
           poetry publish

--- a/.github/workflows/deploy-dev-release.yml
+++ b/.github/workflows/deploy-dev-release.yml
@@ -1,28 +1,33 @@
 ---
-# Deploy a semver prerelease on push to develop.
+# Deploy an auto-versioned semver prerelease on push to develop.
 #
-# This repo adopts Semantic Versioning (see CHANGELOG.md). The published version
-# is read verbatim from pyproject.toml, which carries a prerelease semver such as
-# 0.4.0a0. This workflow no longer calls the shared GRIDAPPSD/.github reusable
-# workflow, because that workflow computes the next version from the highest
-# non-prerelease git tag and git-restores pyproject, ignoring the pyproject
-# version entirely. On this repo the highest such tag is the CalVer v2023.6.1,
-# which always outsorts any semver v0.4.0 tag, so the shared flow keeps trying to
-# republish a CalVer alpha (2023.6.3a0) and fails with a PyPI 400 File already
-# exists. Seeding a v0.4.0 tag cannot win against the CalVer tag. Adopting semver
-# therefore requires deriving the version from pyproject.toml, so the dev job is
-# implemented locally.
+# python-semantic-release is the sole version authority. On a push to develop it
+# reads the conventional-commit history since the last release tag, computes the
+# next prerelease version (feat -> minor, fix -> patch, breaking -> major, always
+# in the 'a' prerelease channel on develop), writes it into pyproject.toml,
+# commits that bump back to develop, and creates the git tag plus a GitHub
+# prerelease. This replaces the earlier manual approach where the version was
+# hand-edited in pyproject.toml on every dev release; the version now derives
+# from what actually changed, per .claude/rules/releasing.md.
 #
-# PyPI is append-only: publishing the same version twice fails. To publish a new
-# prerelease, advance the prerelease number in pyproject.toml (0.4.0a0 to
-# 0.4.0a1, and so on) in the change that lands on develop.
+# After semantic-release commits the bump and tags it, poetry builds the
+# distribution (normalizing the semver 0.4.0-a.N to the PEP440 0.4.0aN that PyPI
+# expects) and twine publishes it. The final step then ASSERTS the just-computed
+# version actually appears on PyPI, so a run cannot report success while
+# publishing nothing.
+#
+# develop is not a protected branch (the repository ruleset covers main only), so
+# the standard GITHUB_TOKEN with contents: write is sufficient to push the bump
+# commit and tag. No GitHub App or bypass PAT is required for the dev channel.
+# The later stable release (develop -> main) is a separate, PR-gated path.
 #
 # GitHub-hosted runner is acceptable here: this is a non-deploy-bearing publish
 # job that authenticates only with the ephemeral GITHUB_TOKEN plus PYPI_TOKEN to
-# create a GitHub prerelease and publish to PyPI. It does not SSH to any target
-# and does not touch a running environment. See .claude/rules/devops.md.
+# push a version bump, create a GitHub prerelease, and publish to PyPI. It does
+# not SSH to any target and does not touch a running environment. See
+# .claude/rules/devops.md.
 
-name: Deploy Pre-Release Artifacts (semver)
+name: Deploy Pre-Release Artifacts (auto-versioned)
 
 on:
   push:
@@ -38,17 +43,25 @@ env:
   LANG: en_US.utf-8
   LC_ALL: en_US.utf-8
   PYTHON_VERSION: '3.10'
+  PACKAGE_NAME: gridappsd-topology-processor
+
+# Least privilege: the only elevated scope needed is contents: write, so
+# semantic-release can push the version-bump commit and the release tag to
+# develop and create the GitHub prerelease.
+permissions:
+  contents: write
 
 jobs:
   deploy-dev-release:
+    # Guard against running on main; the stable release path is separate.
     if: github.ref_name != 'main'
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write  # To create the prerelease
     steps:
       - name: Checkout develop
         uses: actions/checkout@v5
         with:
+          # Full history and tags are required for semantic-release to read the
+          # commit range since the last release and to compute the next version.
           fetch-depth: 0
           ref: develop
 
@@ -57,49 +70,98 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      # semantic-release computes the next prerelease version, writes it into
+      # pyproject.toml, commits the bump back to develop with a [skip ci] marker,
+      # tags the commit, and creates the GitHub prerelease. It does NOT publish
+      # to PyPI (that is poetry + twine below); build is disabled here because
+      # poetry owns the build with PEP440 normalization.
+      - name: Compute version, commit bump, tag, GitHub prerelease
+        id: release
+        uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e  # v10.6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: "github-actions[bot]"
+          git_committer_email: "github-actions[bot]@users.noreply.github.com"
+          # Force the prerelease channel regardless of the bump size, so develop
+          # never cuts a bare-stable version.
+          prerelease: "true"
+          build: "false"
+
+      - name: Report semantic-release decision
+        run: |
+          echo "released:  ${{ steps.release.outputs.released }}"
+          echo "version:   ${{ steps.release.outputs.version }}"
+          echo "tag:       ${{ steps.release.outputs.tag }}"
+          echo "link:      ${{ steps.release.outputs.link }}"
+
+      # Everything below only runs when semantic-release actually cut a release.
+      # A push with no releasable commits (only chore/docs/style, or the bump
+      # commit itself) yields released == false; there is nothing to publish and
+      # the job succeeds without touching PyPI.
       - name: Install Poetry
+        if: ${{ steps.release.outputs.released == 'true' }}
         uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263  # v1.4.2
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Read and validate prerelease version from pyproject
-        id: resolve
+      - name: Sync working tree to the release commit and validate prerelease
+        if: ${{ steps.release.outputs.released == 'true' }}
         run: |
-          VERSION=$(poetry version --short)
-          # The dev channel only ever publishes a prerelease (alpha, beta, rc, or
-          # dev). A bare stable version on develop is a mistake: fail loudly so a
-          # stable version is never published from the dev channel by accident.
-          if ! echo "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc|\.dev)[0-9]+$'; then
-            echo "error: pyproject version '${VERSION}' is not a prerelease; the dev channel publishes prereleases only (for example 0.4.0a0)" >&2
+          # semantic-release committed the version bump; pull it into the working
+          # tree so poetry builds the just-released version, not the pre-bump one.
+          git pull --ff-only origin develop
+          BUILT_VERSION=$(poetry version --short)
+          echo "poetry sees version: ${BUILT_VERSION}"
+          # Defense in depth: the dev channel publishes prereleases only. A bare
+          # stable version here is a mistake; fail loudly rather than publish a
+          # stable artifact from the dev channel.
+          if ! echo "${BUILT_VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc|\.dev)[0-9]+$'; then
+            echo "error: built version '${BUILT_VERSION}' is not a prerelease; the dev channel publishes prereleases only" >&2
             exit 1
           fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Publishing prerelease version: ${VERSION}"
+          echo "built_version=${BUILT_VERSION}" >> "$GITHUB_ENV"
 
-      - name: Build
+      - name: Build distribution
+        if: ${{ steps.release.outputs.released == 'true' }}
         run: |
           poetry build -vvv
 
       - name: Twine check artifacts
+        if: ${{ steps.release.outputs.released == 'true' }}
         run: |
           pip install --quiet twine
           twine check dist/*
 
-      - name: Create GitHub prerelease
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
-        with:
-          artifacts: "dist/*.gz,dist/*.whl"
-          artifactErrorsFailBuild: true
-          generateReleaseNotes: true
-          commit: ${{ github.sha }}
-          prerelease: true
-          tag: "v${{ steps.resolve.outputs.version }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish prerelease to PyPI
-        if: ${{ github.repository_owner == 'GRIDAPPSD' }}
+        if: ${{ steps.release.outputs.released == 'true' && github.repository_owner == 'GRIDAPPSD' }}
         env:
+          # Token is passed via the environment, never interpolated into a run
+          # command line, so it cannot leak into the process table or logs.
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: |
           poetry publish
+
+      # LOUD FAILURE GATE: a green run must mean the artifact actually landed on
+      # PyPI. poetry publish can report success while PyPI ultimately rejects or
+      # drops the upload; this step polls the PyPI JSON API until the exact
+      # just-built version is present, and fails the run if it never appears.
+      - name: Assert version published to PyPI
+        if: ${{ steps.release.outputs.released == 'true' && github.repository_owner == 'GRIDAPPSD' }}
+        env:
+          BUILT_VERSION: ${{ env.built_version }}
+        run: |
+          echo "Asserting ${PACKAGE_NAME} ${BUILT_VERSION} is present on PyPI"
+          # PyPI is eventually consistent after an upload; poll with backoff
+          # rather than checking once. 10 attempts x 15s covers roughly 2.5
+          # minutes, which is well beyond normal index propagation.
+          for attempt in $(seq 1 10); do
+            if curl -sf "https://pypi.org/pypi/${PACKAGE_NAME}/${BUILT_VERSION}/json" >/dev/null; then
+              echo "confirmed: ${PACKAGE_NAME} ${BUILT_VERSION} is on PyPI"
+              exit 0
+            fi
+            echo "attempt ${attempt}: not yet visible on PyPI, waiting 15s"
+            sleep 15
+          done
+          echo "error: ${PACKAGE_NAME} ${BUILT_VERSION} did NOT appear on PyPI after publishing; the upload silently failed" >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0a0] - 2026-07-18
+
+Adopts Semantic Versioning. Prior releases used CalVer (2023.6.1). This is the
+first semver prerelease, an alpha of 0.4.0. The CalVer releases on PyPI are
+yanked so that pip no longer resolves to them; because this is a prerelease,
+installers reach it with the prerelease opt-in (pip install --pre).
+
+### Fixed
+- Canonicalize mRID before the Blazegraph get_object call so topology lookups
+  match stored identifiers rather than failing silently (TO-005).
+
+### Changed
+- Bound the cim-graph dependency below the untested 0.5.0 alpha train to match
+  the gridappsd-python field-bus spec: pin is `>=0.4.3a6,<0.5.0` (TO-001, TO-002).
+
+### Added
+- Test coverage for mRID canonicalization and the None-versus-empty distinction.
+
+[0.4.0a0]: https://github.com/GRIDAPPSD/topology-processor/releases/tag/v0.4.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridappsd-topology-processor"
-version = "0.3.0"
+version = "0.4.0a0"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "gridappsd-topology-processor"
 # published to PyPI carries the PEP440 spelling PyPI expects. Do not hand-edit
 # this string on develop: the dev-deploy workflow owns it. See
 # .github/workflows/deploy-dev-release.yml and [tool.semantic_release] below.
-version = "0.4.0-a.0"
+version = "0.4.0-a.1"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",
@@ -54,9 +54,16 @@ build-backend = "poetry.core.masonry.api"
 # semantic-release is strictly SemVer; PyPI and poetry are PEP440. The two forms
 # are equivalent for alpha prereleases: semantic-release writes 0.4.0-a.N and
 # poetry build normalizes it to 0.4.0aN. The baseline tag MUST be the SemVer form
-# (v0.4.0-a.0) so semantic-release can parse it; a PEP440-form tag such as
+# (v0.4.0-a.1) so semantic-release can parse it; a PEP440-form tag such as
 # v0.4.0a0 is unparseable to semantic-release and forces the baseline back to
 # 0.0.0, restarting version numbering.
+#
+# The prerelease revision MUST be >= 1 when seeding. Never seed revision 0
+# (v0.4.0-a.0). python-semantic-release v10.6.1 treats a prerelease revision of 0
+# as falsy: it drops the ".0" suffix and stringifies the seed as the bare
+# v0.4.0, then runs git rev-list against that nonexistent tag and dies. It also
+# reads a bare v0.4.0 as a shipped full release, which kills the prerelease
+# channel. Seed at v0.4.0-a.1 and let semantic-release count up from there.
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
 tag_format = "v{version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ documentation = "https://github.com/GRIDAPPSD/topology-processor"
 python = "^3.10"
 #gridappsd-python = {version = "^2024.6.0", allow-prereleases = true}
 #cim-topology = { git = "https://github.com/PNNL-CIM-Tools/CIM-Graph-Topology-Processor", branch = "cimgraph-refactor"}
-cim-graph = ">=0.4.3a6"
+cim-graph = ">=0.4.3a6,<0.5.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.poetry]
 name = "gridappsd-topology-processor"
-version = "0.4.0a0"
+# SemVer prerelease form is required by python-semantic-release, which computes
+# the next version and writes it here. poetry normalizes this to the PEP440 form
+# (0.4.0-a.1 becomes 0.4.0a1) when it builds the distribution, so the artifact
+# published to PyPI carries the PEP440 spelling PyPI expects. Do not hand-edit
+# this string on develop: the dev-deploy workflow owns it. See
+# .github/workflows/deploy-dev-release.yml and [tool.semantic_release] below.
+version = "0.4.0-a.0"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",
@@ -36,3 +42,36 @@ pre-commit = "^3.3.2"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+# python-semantic-release: sole version authority for the dev channel.
+#
+# On a push to develop the deploy-dev-release workflow runs semantic-release,
+# which reads the conventional-commit history since the last release tag,
+# computes the next prerelease version (feat -> minor, fix -> patch, breaking ->
+# major, always in the 'a' prerelease channel on develop), writes it into
+# tool.poetry.version above, commits that bump back to develop, and tags it.
+#
+# semantic-release is strictly SemVer; PyPI and poetry are PEP440. The two forms
+# are equivalent for alpha prereleases: semantic-release writes 0.4.0-a.N and
+# poetry build normalizes it to 0.4.0aN. The baseline tag MUST be the SemVer form
+# (v0.4.0-a.0) so semantic-release can parse it; a PEP440-form tag such as
+# v0.4.0a0 is unparseable to semantic-release and forces the baseline back to
+# 0.0.0, restarting version numbering.
+[tool.semantic_release]
+version_toml = ["pyproject.toml:tool.poetry.version"]
+tag_format = "v{version}"
+# The project is pre-1.0; allow 0.x versions and do not let a feat/breaking
+# change on a 0.x line jump straight to 1.0.0.
+allow_zero_version = true
+major_on_zero = false
+commit_parser = "conventional"
+# [skip ci] keeps the bump commit from re-triggering this workflow into a loop.
+# A GITHUB_TOKEN-authored push does not trigger workflow runs either, so this is
+# belt-and-suspenders; keep it so a future switch to a PAT stays loop-safe.
+commit_message = "chore(release): {version} [skip ci]"
+build_command = ""
+
+[tool.semantic_release.branches.develop]
+match = "develop"
+prerelease = true
+prerelease_token = "a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "gridappsd-topology-processor"
 # published to PyPI carries the PEP440 spelling PyPI expects. Do not hand-edit
 # this string on develop: the dev-deploy workflow owns it. See
 # .github/workflows/deploy-dev-release.yml and [tool.semantic_release] below.
-version = "0.4.0-a.1"
+version = "0.4.0-a.2"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ documentation = "https://github.com/GRIDAPPSD/topology-processor"
 python = "^3.10"
 #gridappsd-python = {version = "^2024.6.0", allow-prereleases = true}
 #cim-topology = { git = "https://github.com/PNNL-CIM-Tools/CIM-Graph-Topology-Processor", branch = "cimgraph-refactor"}
-cim-graph = "^0.1.8a0"
+cim-graph = ">=0.4.3a6"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_mrid_canonicalize.py
+++ b/tests/test_mrid_canonicalize.py
@@ -1,0 +1,181 @@
+"""Unit tests for the TO-005 caller-side mRID fix in topo_background_service.
+
+topo_background_service imports gridappsd and cimgraph at module scope; those are
+container-only dependencies. We stub them in sys.modules before import so the
+pure-Python canonicalization and the None-vs-empty distinction can be exercised
+without the broker or Blazegraph.
+"""
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _install_stubs():
+    """Register lightweight stand-ins for the container-only dependencies."""
+
+    class _Feeder:
+        pass
+
+    class _FeederArea:
+        pass
+
+    class _DistributionArea:
+        pass
+
+    class _GridAPPSD:
+        def __init__(self, *a, **k):
+            self.connected = True
+
+        def get_logger(self):
+            return mock.MagicMock()
+
+    gridappsd_mod = types.ModuleType('gridappsd')
+    gridappsd_mod.GridAPPSD = _GridAPPSD
+    sys.modules['gridappsd'] = gridappsd_mod
+
+    cimgraph = types.ModuleType('cimgraph')
+    databases = types.ModuleType('cimgraph.databases')
+    blazegraph = types.ModuleType('cimgraph.databases.blazegraph')
+    blazegraph.BlazegraphConnection = mock.MagicMock
+    databases.blazegraph = blazegraph
+    cimgraph.databases = databases
+    sys.modules['cimgraph'] = cimgraph
+    sys.modules['cimgraph.databases'] = databases
+    sys.modules['cimgraph.databases.blazegraph'] = blazegraph
+
+    cim = types.ModuleType('cimgraph.data_profile.cimhub_2023')
+    cim.Feeder = _Feeder
+    cim.FeederArea = _FeederArea
+    cim.DistributionArea = _DistributionArea
+    data_profile = types.ModuleType('cimgraph.data_profile')
+    data_profile.cimhub_2023 = cim
+    cimgraph.data_profile = data_profile
+    sys.modules['cimgraph.data_profile'] = data_profile
+    sys.modules['cimgraph.data_profile.cimhub_2023'] = cim
+
+    class _DistributedTopologyMessage:
+        def __init__(self):
+            self.message = {'DistributionArea': {}}
+
+        def get_context_from_feeder(self, *a, **k):
+            # Simulate a populated topology for the resolved-Feeder success case.
+            self.message['DistributionArea'] = {'@id': 'stub', 'Substations': []}
+
+        def get_context_from_feeder_area(self, *a, **k):
+            pass
+
+        def get_context_from_distribution_area(self, *a, **k):
+            pass
+
+    utils = types.ModuleType('topology_processor.utils')
+    utils.DistributedTopologyMessage = _DistributedTopologyMessage
+    tp = types.ModuleType('topology_processor')
+    tp.utils = utils
+    sys.modules.setdefault('topology_processor', tp)
+    sys.modules['topology_processor.utils'] = utils
+
+    dotenv = types.ModuleType('dotenv')
+    dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules['dotenv'] = dotenv
+
+    return cim
+
+
+@pytest.fixture(scope='module')
+def svc_module():
+    _install_stubs()
+    mod = importlib.import_module('topo_background_service')
+    return importlib.reload(mod)
+
+
+# --- canonicalization ---------------------------------------------------------
+
+# ieee123 Feeder mRID stored by Blazegraph as bare lowercase urn:uuid.
+CANONICAL = 'c1c3e687-6ffd-c753-582b-632a27e28507'
+
+
+@pytest.mark.parametrize('raw', [
+    'C1C3E687-6FFD-C753-582B-632A27E28507',      # plain uppercase (FieldBusManager form)
+    'c1c3e687-6ffd-c753-582b-632a27e28507',      # already canonical
+    '_C1C3E687-6FFD-C753-582B-632A27E28507',     # underscore-prefixed RDF ID, uppercase
+    '_c1c3e687-6ffd-c753-582b-632a27e28507',     # underscore-prefixed, lowercase
+    'C1c3E687-6ffd-C753-582b-632A27e28507',      # mixed case
+])
+def test_canonicalize_maps_any_form_to_bare_lowercase(svc_module, raw):
+    assert svc_module.canonicalize_mrid(raw) == CANONICAL
+
+
+@pytest.mark.parametrize('bad', ['not-a-uuid', '', 'urn:uuid:xyz', None, 12345])
+def test_canonicalize_returns_none_for_malformed(svc_module, bad):
+    assert svc_module.canonicalize_mrid(bad) is None
+
+
+# --- None-vs-empty distinction ------------------------------------------------
+
+def _build_service(svc_module, get_object_return):
+    """Construct a TopologyProcessor with __init__ bypassed and a stubbed conn."""
+    svc = svc_module.TopologyProcessor.__new__(svc_module.TopologyProcessor)
+    svc.gapps = mock.MagicMock()
+    svc.log = mock.MagicMock()
+    svc.blazegraph = mock.MagicMock()
+    svc.blazegraph.get_object.return_value = get_object_return
+    svc.return_message = {}
+    return svc
+
+
+def _sent_payload(svc):
+    assert svc.gapps.send.called, 'service never sent a reply'
+    return svc.gapps.send.call_args.args[1]
+
+
+def test_unresolved_mrid_signals_not_found_not_empty_success(svc_module):
+    """get_object -> None must produce a distinguishable not-found error, not {}."""
+    svc = _build_service(svc_module, get_object_return=None)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS',
+               'mRID': 'C1C3E687-6FFD-C753-582B-632A27E28507'}
+
+    svc.on_message(headers, message)
+
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' in payload, 'None path must emit an explicit error field'
+    assert 'DistributionArea' not in payload, 'must not masquerade as empty-but-valid topology'
+    assert svc.log.error.called, 'None path must log an actionable error'
+
+
+def test_malformed_mrid_signals_error_before_query(svc_module):
+    svc = _build_service(svc_module, get_object_return=None)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS', 'mRID': 'not-a-uuid'}
+
+    svc.on_message(headers, message)
+
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' in payload
+    svc.blazegraph.get_object.assert_not_called()
+    assert svc.log.error.called
+
+
+def test_resolved_feeder_keeps_success_shape(svc_module):
+    """A genuine Feeder still yields the DistributionArea success message."""
+    feeder = svc_module.cim.Feeder()
+    svc = _build_service(svc_module, get_object_return=feeder)
+    headers = {'reply-to': 'reply.topic'}
+    message = {'requestType': 'GET_DISTRIBUTED_AREAS',
+               'mRID': 'C1C3E687-6FFD-C753-582B-632A27E28507'}
+
+    svc.on_message(headers, message)
+
+    # get_object was called with the canonicalized mRID, not the raw uppercase form.
+    svc.blazegraph.get_object.assert_called_once_with(mRID=CANONICAL)
+    payload = json.loads(_sent_payload(svc))
+    assert 'error' not in payload
+    assert 'DistributionArea' in payload

--- a/topo_background_service.py
+++ b/topo_background_service.py
@@ -1,12 +1,30 @@
 import os
 import json
 import time
+from uuid import UUID
 from gridappsd import GridAPPSD
 from cimgraph.databases.blazegraph import BlazegraphConnection
 
 from topology_processor.utils import DistributedTopologyMessage
 import cimgraph.data_profile.cimhub_2023 as cim
 from dotenv import load_dotenv
+
+
+def canonicalize_mrid(mrid: str) -> str | None:
+    """Normalize an mRID to the bare lowercase UUID that Blazegraph stores.
+
+    FieldBusManager sends the mRID in varied forms (plain uppercase UUID,
+    underscore-prefixed RDF ID, mixed case). cimgraph's create_object keys the
+    graph on UUID(uri.strip('_').lower()) but get_object_sparql does not
+    canonicalize the lookup, so an uncanonicalized mRID silently misses. Parse
+    to a UUID here (matching create_object) so the lookup is robust to any input
+    form. Returns None when the mRID is not a valid UUID so the caller can fail
+    loudly instead of querying with garbage.
+    """
+    try:
+        return str(UUID(mrid.strip('_').lower()))
+    except (ValueError, AttributeError):
+        return None
 
 # Uncomment and set following environment variables if testing outside GridAPPS-D container
 #os.environ["GRIDAPPSD_ADDRESS"] = ''
@@ -49,18 +67,37 @@ class TopologyProcessor(GridAPPSD):
                 self.gapps.send(reply_to, self.return_message[model_mrid])
             
             else:
-            
+
+                query_mrid = canonicalize_mrid(model_mrid)
+                if query_mrid is None:
+                    error = f'mRID {model_mrid!r} is not a valid UUID; cannot build topology'
+                    self.log.error(error)
+                    self.gapps.send(reply_to, json.dumps({'error': error}, indent=4))
+                    return
+
                 topo_message = DistributedTopologyMessage()
-                container = self.blazegraph.get_object(mRID=model_mrid)
+                container = self.blazegraph.get_object(mRID=query_mrid)
 
                 if isinstance(container, cim.Feeder):
                     topo_message.get_context_from_feeder(container, self.blazegraph)
 
                 elif isinstance(container, cim.FeederArea):
                     topo_message.get_context_from_feeder_area(container, self.blazegraph)
-                    
+
                 elif isinstance(container, cim.DistributionArea):
                     topo_message.get_context_from_distribution_area(container, self.blazegraph)
+
+                elif container is None:
+                    # get_object found no container for this mRID. Do NOT serialize
+                    # an empty DistributionArea as success: the caller cannot tell
+                    # that from a legitimately-empty topology. Signal not-found
+                    # explicitly so FieldBusManager can distinguish the two.
+                    error = (f'No container resolved for mRID {model_mrid!r} '
+                             f'(queried as {query_mrid}); topology not built')
+                    self.log.error(error)
+                    del topo_message
+                    self.gapps.send(reply_to, json.dumps({'error': error}, indent=4))
+                    return
 
                 self.return_message[model_mrid] = json.dumps(topo_message.message, indent=4)
                 del topo_message


### PR DESCRIPTION
Promotes all of develop to main. Carries: GADP-007 cimgraph mRID canonicalization fix (the fix the GOSS image needs, since the Dockerfile clones topology-processor -b main), the semver/CI adoption (repo-local dev-deploy, semantic-release, 0.4.0-a.2), and the cimgraph pin bounds (>=0.4.3a6,<0.5.0). The cimgraph pin travels WITH the mRID fix so canonicalize runs against the tested cimgraph. Unblocks GADP-047 end-to-end verification. No dashes-as-punctuation.