### PR TITLE
Stable release tooling and 0.4.0 version prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,219 @@
+---
+# Cut a STABLE semver release (vX.Y.Z, no prerelease suffix) from main.
+#
+# DELIBERATE DISPATCH ONLY. This workflow never triggers on push. It runs only
+# via workflow_dispatch, and the release_mode input defaults to "dry-run". An
+# operator who clicks "Run workflow" with no changes gets a harmless smoke check
+# that builds and twine-checks the artifact but publishes nothing, creates no
+# tag, and creates no GitHub release. Cutting a real release requires explicitly
+# setting release_mode to "real". This eliminates the failure class where an
+# accidental or automated merge cuts an unintended stable release. See
+# .claude/rules/releasing.md section 1.
+#
+# VERSION AUTHORITY, and why this is not the dev workflow's psr-computes path.
+# python-semantic-release v10.6.1 has no operation that finalizes a prerelease
+# line (0.4.0-a.N) into its stable counterpart (0.4.0). Its stable channel
+# ignores prerelease tags entirely: it reports "No full releases found", falls
+# back to a 0.0.0 baseline, and would compute 0.0.1. The repository's tag
+# history compounds this: the only prior full tag is the unreachable CalVer
+# v2023.6.1, which poisons psr's stable base resolution. For the first stable
+# cut off this history, pyproject.toml is therefore the single source of truth
+# for the version, and the tag is created explicitly here. Once v0.4.0 exists as
+# a reachable stable tag, psr's stable channel resolves correctly again
+# (a fix commit computes 0.4.1, a feat computes 0.5.0, both verified locally),
+# so 0.4.1 and later MAY move to a psr-driven path. This workflow is the
+# deterministic first-stable-cut path.
+#
+# GitHub-hosted runner is acceptable: this is a non-deploy-bearing publish job
+# authenticating only with the ephemeral GITHUB_TOKEN plus PYPI_TOKEN. It does
+# not SSH to any target and does not touch a running environment. See
+# .claude/rules/devops.md.
+
+name: Cut Stable Release (deliberate dispatch)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: >-
+          dry-run builds and twine-checks only (no publish, no tag, no release).
+          real publishes to PyPI, tags the commit, and creates the GitHub release.
+        type: choice
+        required: true
+        default: dry-run
+        options:
+          - dry-run
+          - real
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  LANG: en_US.utf-8
+  LC_ALL: en_US.utf-8
+  PYTHON_VERSION: '3.10'
+  PACKAGE_NAME: gridappsd-topology-processor
+
+# Least privilege. contents: write is needed only in real mode to push the tag
+# and create the GitHub release. dry-run does not exercise the write scope.
+permissions:
+  contents: write
+
+jobs:
+  cut-stable-release:
+    # Stable releases come from main only.
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          # Full history and tags: the tag-existence guard and the version
+          # readback both need them.
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263  # v1.4.2
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      # PRE-FLIGHT: assert the PyPI token is present before doing any work, so a
+      # real run fails loudly here rather than after building. Skipped in
+      # dry-run, which never publishes. See .claude/rules/releasing.md section 5.
+      - name: Pre-flight assert PyPI token present (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' }}
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if [ -z "${POETRY_PYPI_TOKEN_PYPI}" ]; then
+            echo "error: PYPI_TOKEN secret is missing or empty; cannot publish a real release" >&2
+            exit 1
+          fi
+          echo "PyPI token is present"
+
+      # The version is read from pyproject.toml (the source of truth for the
+      # first stable cut) and must be a bare stable version: no a/b/rc/.dev
+      # suffix. A prerelease suffix here means main was not prepared for a stable
+      # release; fail loudly rather than tag or publish a prerelease as stable.
+      - name: Read and validate stable version
+        id: version
+        run: |
+          RELEASE_VERSION=$(poetry version --short)
+          echo "pyproject version: ${RELEASE_VERSION}"
+          if ! echo "${RELEASE_VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "error: version '${RELEASE_VERSION}' is not a bare stable X.Y.Z; main must be prepared with a stable version before a stable release" >&2
+            exit 1
+          fi
+          echo "release_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=v${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      # A stable tag must not already exist on the remote. PyPI is append-only
+      # and tags are immutable; re-cutting an existing version is a mistake.
+      - name: Assert release tag does not already exist on origin
+        run: |
+          TAG="${{ steps.version.outputs.release_tag }}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}"; then
+            echo "error: tag ${TAG} already exists on origin; a stable release for this version was already cut" >&2
+            exit 1
+          fi
+          echo "tag ${TAG} is free on origin"
+
+      - name: Build distribution
+        run: |
+          poetry build -vvv
+
+      - name: Twine check artifacts
+        run: |
+          pip install --quiet twine
+          twine check dist/*
+
+      - name: Dry-run summary (no publish, no tag, no release)
+        if: ${{ github.event.inputs.release_mode == 'dry-run' }}
+        run: |
+          echo "DRY RUN: built and twine-checked ${PACKAGE_NAME} ${{ steps.version.outputs.release_version }}"
+          echo "DRY RUN: no publish to PyPI, no tag ${{ steps.version.outputs.release_tag }}, no GitHub release"
+          echo "To cut the real release, re-run with release_mode=real"
+
+      # ----- Everything below runs only in real mode on the GRIDAPPSD org. -----
+
+      - name: Publish stable release to PyPI (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
+        env:
+          # Token is passed via the environment, never interpolated into a run
+          # command line, so it cannot leak into the process table or logs.
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry publish
+
+      - name: Create and push the release tag (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
+        run: |
+          TAG="${{ steps.version.outputs.release_tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Annotated tag on the current main commit.
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+      - name: Create the GitHub release (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.release_tag }}"
+          # Release notes come from CHANGELOG.md when present; gh generates a
+          # notes body from commits as a fallback.
+          if [ -f CHANGELOG.md ]; then
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --notes-file CHANGELOG.md \
+              dist/*
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes \
+              dist/*
+          fi
+
+      # LOUD FAILURE GATE 1: the tag must actually be on the remote. A green real
+      # run that did not land the tag is a false success.
+      - name: Assert tag pushed to origin (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
+        run: |
+          TAG="${{ steps.version.outputs.release_tag }}"
+          if ! git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}"; then
+            echo "error: tag ${TAG} did NOT land on origin after the release; the tag push silently failed" >&2
+            exit 1
+          fi
+          echo "confirmed: tag ${TAG} is on origin"
+
+      # LOUD FAILURE GATE 2: the artifact must actually be on PyPI. poetry
+      # publish can report success while PyPI ultimately rejects or drops the
+      # upload; poll the PyPI JSON API until the exact version is present.
+      - name: Assert version published to PyPI (real mode)
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: |
+          echo "Asserting ${PACKAGE_NAME} ${RELEASE_VERSION} is present on PyPI"
+          # PyPI is eventually consistent after an upload; poll with backoff.
+          # 10 attempts x 15s covers roughly 2.5 minutes, well beyond normal
+          # index propagation.
+          for attempt in $(seq 1 10); do
+            if curl -sf "https://pypi.org/pypi/${PACKAGE_NAME}/${RELEASE_VERSION}/json" >/dev/null; then
+              echo "confirmed: ${PACKAGE_NAME} ${RELEASE_VERSION} is on PyPI"
+              exit 0
+            fi
+            echo "attempt ${attempt}: not yet visible on PyPI, waiting 15s"
+            sleep 15
+          done
+          echo "error: ${PACKAGE_NAME} ${RELEASE_VERSION} did NOT appear on PyPI after publishing; the upload silently failed" >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ on:
           - dry-run
           - real
 
+# Serialize real dispatches. Two overlapping runs must never race the tag push
+# or the PyPI publish against each other; queue rather than cancel so an
+# in-flight publish is allowed to finish before the next run starts.
+concurrency:
+  group: stable-release
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -67,7 +74,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Full history and tags: the tag-existence guard and the version
           # readback both need them.
@@ -89,7 +96,7 @@ jobs:
       # real run fails loudly here rather than after building. Skipped in
       # dry-run, which never publishes. See .claude/rules/releasing.md section 5.
       - name: Pre-flight assert PyPI token present (real mode)
-        if: ${{ github.event.inputs.release_mode == 'real' }}
+        if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: |
@@ -143,6 +150,18 @@ jobs:
           echo "To cut the real release, re-run with release_mode=real"
 
       # ----- Everything below runs only in real mode on the GRIDAPPSD org. -----
+      #
+      # ORDERING NOTE (publish, then tag, then GitHub release). PyPI is
+      # append-only: a version can be uploaded exactly once and never replaced.
+      # So if the PyPI publish below succeeds but a later step fails (the tag
+      # push, the GitHub release, or a loud-failure gate), this run is NOT
+      # retryable as-is. Re-running would attempt to publish the same version and
+      # PyPI would reject it. Recovery is a FRESH version bump on main (a new
+      # X.Y.Z in pyproject.toml, a new CHANGELOG section) followed by a new
+      # dispatch, never a re-run of this workflow against the already-published
+      # version. Publishing first is deliberate: PyPI availability is the
+      # irreversible act, and the tag and release are cheap to recreate against a
+      # new version if they fail.
 
       - name: Publish stable release to PyPI (real mode)
         if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
@@ -167,14 +186,25 @@ jobs:
         if: ${{ github.event.inputs.release_mode == 'real' && github.repository_owner == 'GRIDAPPSD' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
         run: |
           TAG="${{ steps.version.outputs.release_tag }}"
-          # Release notes come from CHANGELOG.md when present; gh generates a
-          # notes body from commits as a fallback.
+          # Release notes come from the version's own CHANGELOG section, not the
+          # whole file: extract the block under "## [<version>]" up to the next
+          # "## [" header. Fall back to gh's commit-generated notes when the
+          # CHANGELOG or the matching section is absent.
+          NOTES_FILE="$(mktemp)"
           if [ -f CHANGELOG.md ]; then
+            awk -v ver="${RELEASE_VERSION}" '
+              $0 ~ "^## \\[" ver "\\]" { grab = 1; print; next }
+              grab && /^## \[/ { exit }
+              grab { print }
+            ' CHANGELOG.md > "${NOTES_FILE}"
+          fi
+          if [ -s "${NOTES_FILE}" ]; then
             gh release create "${TAG}" \
               --title "${TAG}" \
-              --notes-file CHANGELOG.md \
+              --notes-file "${NOTES_FILE}" \
               dist/*
           else
             gh release create "${TAG}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-18
+
+First stable semver release. Promotes the 0.4.0 alpha line to a stable cut and
+completes the move off CalVer (2023.6.1). Published to PyPI as a bare stable
+version, so `pip install gridappsd-topology-processor` resolves to it without
+the prerelease opt-in.
+
+### Added
+- Deliberate-dispatch stable release workflow: a `workflow_dispatch` pipeline
+  that defaults to dry-run and cuts a real release only when explicitly set to
+  real. pyproject.toml is the version source of truth; the workflow tags v0.4.0
+  and publishes to PyPI (TO-001).
+- Test coverage for mRID canonicalization and the None-versus-empty distinction.
+
+### Changed
+- Adopt Semantic Versioning in place of CalVer, with python-semantic-release
+  driving the dev prerelease channel on develop (TO-001, TO-002).
+- Bound the cim-graph dependency below the untested 0.5.0 alpha train to match
+  the gridappsd-python field-bus spec: pin is `>=0.4.3a6,<0.5.0` (TO-001, TO-002).
+
+### Fixed
+- Canonicalize mRID before the Blazegraph get_object call so topology lookups
+  match stored identifiers rather than failing silently (TO-005).
+
 ## [0.4.0a0] - 2026-07-18
 
 Adopts Semantic Versioning. Prior releases used CalVer (2023.6.1). This is the
@@ -23,4 +47,5 @@ installers reach it with the prerelease opt-in (pip install --pre).
 ### Added
 - Test coverage for mRID canonicalization and the None-versus-empty distinction.
 
+[0.4.0]: https://github.com/GRIDAPPSD/topology-processor/releases/tag/v0.4.0
 [0.4.0a0]: https://github.com/GRIDAPPSD/topology-processor/releases/tag/v0.4.0a0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,17 @@
 [tool.poetry]
 name = "gridappsd-topology-processor"
-# SemVer prerelease form is required by python-semantic-release, which computes
-# the next version and writes it here. poetry normalizes this to the PEP440 form
-# (0.4.0-a.1 becomes 0.4.0a1) when it builds the distribution, so the artifact
-# published to PyPI carries the PEP440 spelling PyPI expects. Do not hand-edit
-# this string on develop: the dev-deploy workflow owns it. See
-# .github/workflows/deploy-dev-release.yml and [tool.semantic_release] below.
-version = "0.4.0-a.2"
+# On main this is the source of truth for the first stable cut: a bare stable
+# X.Y.Z, no a/b/rc/.dev suffix. The Cut Stable Release workflow reads it, tags
+# vX.Y.Z explicitly, and publishes. python-semantic-release cannot finalize a
+# prerelease line (0.4.0-a.N) into its stable counterpart, so the stable version
+# is set here by hand. See .github/workflows/release.yml.
+#
+# On develop this string is owned by the dev-deploy workflow: semantic-release
+# computes the next prerelease (0.4.0-a.N in SemVer form, which poetry normalizes
+# to 0.4.0aN PEP440 at build time) and writes it here. Do not hand-edit it on
+# develop. See .github/workflows/deploy-dev-release.yml and
+# [tool.semantic_release] below.
+version = "0.4.0"
 description = ""
 authors = [
     "A. Anderson <19935503+AAndersn@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

Release-tooling and version prep for the first stable cut of
`gridappsd-topology-processor`. This PR does NOT cut a release; the actual
release is a separate, gated `workflow_dispatch` run after this merges.

Two logical changes:

1. **Stable release workflow (`.github/workflows/release.yml`)** with review
   nits applied on top of the approved draft:
   - `concurrency: { group: stable-release, cancel-in-progress: false }` at the
     workflow level so two real dispatches cannot race the tag push or the PyPI
     publish.
   - Owner-gate (`github.repository_owner == 'GRIDAPPSD'`) on the pre-flight
     PYPI_TOKEN assert step, matching the publish, tag, and release steps.
   - `actions/checkout` pinned to `v6` (current stable major, per devops.md).
     `snok/install-poetry` stays SHA-pinned.
   - GitHub release notes now come from the version's own CHANGELOG section
     rather than the whole file.
   - A comment documenting the publish-then-tag ordering: because PyPI is
     append-only, a failed tag push after a successful publish requires a fresh
     version bump, not a re-run.

2. **Stable version bump**: `pyproject.toml` version set to a bare `0.4.0`
   (dropping the `-a.2` prerelease suffix), plus a `0.4.0` stable CHANGELOG
   section (Keep a Changelog) covering the mRID canonicalization fix, the
   cim-graph pin bounds, and the semver plus CI adoption.

## Version authority

python-semantic-release cannot finalize a prerelease line (`0.4.0-a.N`) into its
stable counterpart, so for this first stable cut `pyproject.toml` is the version
source of truth and the workflow tags `v0.4.0` explicitly. Once `v0.4.0` is a
reachable stable tag, later patches MAY move to a psr-driven path.

## Release model

Deliberate dispatch only. The workflow defaults to `dry-run`; cutting a real
release requires explicitly setting `release_mode=real`. Merging this PR does
NOT trigger a release.

## Not in scope

The docker stack is handled separately.